### PR TITLE
Add IBAN validation to SEPA credit transfer form

### DIFF
--- a/app/frontend/src/components/views/SepaCreditTransfers.svelte
+++ b/app/frontend/src/components/views/SepaCreditTransfers.svelte
@@ -19,10 +19,25 @@
 
   let ibanError = $state('')
 
+  // Expected IBAN lengths per country (ISO 13616 / SWIFT registry)
+  const IBAN_LENGTHS = {
+    AD:28,AE:23,AL:28,AT:20,AZ:28,BA:20,BE:16,BG:22,BH:22,BR:29,BY:28,CH:21,
+    CR:22,CY:28,CZ:24,DE:22,DK:18,DO:28,EE:20,EG:29,ES:24,FI:18,FO:18,FR:27,
+    GB:22,GE:22,GI:23,GL:18,GT:28,HR:21,HU:28,IE:22,IL:23,IQ:23,IS:26,IT:27,
+    JO:30,KW:30,KZ:20,LB:28,LC:32,LI:21,LT:20,LU:20,LV:21,MC:27,MD:24,ME:22,
+    MK:19,MR:27,MT:31,MU:30,NI:28,NL:18,NO:15,PK:24,PL:28,PS:29,PT:25,QA:29,
+    RO:24,RS:22,SA:24,SC:31,SE:24,SI:19,SK:24,SM:27,ST:25,SV:28,TL:23,TN:24,
+    TR:26,UA:29,VA:22,VG:24,XK:20,
+  }
+
   function validateIban(value) {
     const iban = value.replace(/\s+/g, '').toUpperCase()
     if (!iban) return ''
     if (!/^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/.test(iban)) return 'Invalid IBAN format'
+    const country = iban.slice(0, 2)
+    const expectedLength = IBAN_LENGTHS[country]
+    if (!expectedLength) return `Unsupported country code: ${country}`
+    if (iban.length !== expectedLength) return `Invalid length for ${country} IBAN (expected ${expectedLength} characters)`
     const rearranged = iban.slice(4) + iban.slice(0, 4)
     const numeric = rearranged.split('').map(c => c >= 'A' ? String(c.charCodeAt(0) - 55) : c).join('')
     let remainder = 0

--- a/app/frontend/src/components/views/SepaCreditTransfers.svelte
+++ b/app/frontend/src/components/views/SepaCreditTransfers.svelte
@@ -17,6 +17,25 @@
     end_to_end_id: '',
   })
 
+  let ibanError = $state('')
+
+  function validateIban(value) {
+    const iban = value.replace(/\s+/g, '').toUpperCase()
+    if (!iban) return ''
+    if (!/^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/.test(iban)) return 'Invalid IBAN format'
+    const rearranged = iban.slice(4) + iban.slice(0, 4)
+    const numeric = rearranged.split('').map(c => c >= 'A' ? String(c.charCodeAt(0) - 55) : c).join('')
+    let remainder = 0
+    for (let i = 0; i < numeric.length; i++) {
+      remainder = (remainder * 10 + parseInt(numeric[i], 10)) % 97
+    }
+    return remainder === 1 ? '' : 'IBAN checksum is invalid'
+  }
+
+  function onIbanInput() {
+    ibanError = validateIban(form.creditor_iban)
+  }
+
   let debtorQuery = $state('')
   let debtorOpen  = $state(false)
 
@@ -43,6 +62,7 @@
       remittance_information: '',
       end_to_end_id: '',
     }
+    ibanError = ''
     debtorQuery = ''
     debtorOpen = false
     showModal = true
@@ -61,6 +81,8 @@
   }
 
   async function handleSubmit() {
+    ibanError = validateIban(form.creditor_iban)
+    if (ibanError) return
     try {
       await createSepaCreditTransfer({
         debtor_account_id:      form.debtor_account_id,
@@ -206,7 +228,17 @@
           </div>
           <div>
             <label class="field-label" for="creditor-iban">Creditor IBAN</label>
-            <input id="creditor-iban" class="field-input font-mono" required bind:value={form.creditor_iban} placeholder="DE89370400440532013000"/>
+            <input
+              id="creditor-iban"
+              class="field-input font-mono {ibanError ? 'border-red-400 focus:ring-red-300' : ''}"
+              required
+              bind:value={form.creditor_iban}
+              oninput={onIbanInput}
+              placeholder="DE89370400440532013000"
+            />
+            {#if ibanError}
+              <p class="mt-1 text-xs text-red-500">{ibanError}</p>
+            {/if}
           </div>
           <div>
             <label class="field-label" for="creditor-bic">Creditor BIC <span class="text-zinc-400 font-normal">(optional)</span></label>


### PR DESCRIPTION
## Summary
Added client-side IBAN validation to the SEPA credit transfer form with real-time feedback and submission blocking for invalid IBANs.

## Key Changes
- Implemented `validateIban()` function that performs comprehensive IBAN validation:
  - Checks format against IBAN standard (2 letter country code, 2 check digits, alphanumeric body)
  - Validates checksum using the mod-97 algorithm as per ISO 13616 specification
- Added real-time validation on input with `onIbanInput()` handler that updates error state as user types
- Enhanced form submission to validate IBAN before attempting to create transfer, preventing invalid submissions
- Updated UI to display validation errors in red text below the IBAN input field
- Added visual feedback with red border and ring styling when IBAN is invalid
- Reset error state when form is cleared

## Implementation Details
- IBAN validation uses the standard mod-97 checksum algorithm: rearranges IBAN (move first 4 chars to end), converts letters to numbers (A=10, B=11, etc.), and verifies remainder equals 1
- Validation is non-blocking during input (user can continue typing) but prevents form submission if invalid
- Error messages are user-friendly and specific ("Invalid IBAN format" vs "IBAN checksum is invalid")

https://claude.ai/code/session_01AQNypGsAwgPzRKViMfPLBw