### PR TITLE
Refactor scope fetching to include user's current scope

### DIFF
--- a/app/frontend/src/components/Sidebar.svelte
+++ b/app/frontend/src/components/Sidebar.svelte
@@ -51,23 +51,26 @@
   })
 
   async function fetchScopes() {
+    let meScope = null
+    try {
+      const me = await apiFetch('GET', '/me/', null, { scope: false })
+      if (me.scope) meScope = { id: me.scope.id, name: me.scope.name }
+    } catch {}
+
     try {
       const res = await apiFetch('GET', '/scopes/?limit=200', null, { scope: false })
-      scopeOptions = res.data.map(e => e.attributes)
+      const scopes = res.data.map(e => e.attributes).filter(s => s.status !== 'pending_approval')
+      if (meScope && !scopes.find(s => s.id === meScope.id)) {
+        scopes.push(meScope)
+      }
+      scopeOptions = scopes
       if (!auth.scope) {
         const root = scopeOptions.find(s => !s.parent_scope_id)
         if (root) setScope(root.id)
       }
-    } catch { scopeOptions = [] }
-
-    if (scopeOptions.length === 0) {
-      try {
-        const me = await apiFetch('GET', '/me/', null, { scope: false })
-        if (me.scope) {
-          scopeOptions = [{ id: me.scope.id, name: me.scope.name }]
-          if (!auth.scope) setScope(me.scope.id)
-        }
-      } catch {}
+    } catch {
+      scopeOptions = meScope ? [meScope] : []
+      if (meScope && !auth.scope) setScope(meScope.id)
     }
 
     scopesFetched = true


### PR DESCRIPTION
## Summary
Refactored the `fetchScopes()` function in the Sidebar component to improve how user scopes are handled. The function now fetches the user's current scope upfront and ensures it's always available in the scope options, even if it's not in the main scopes list.

## Key Changes
- Moved the `/me/` API call to the beginning of the function to fetch the user's current scope first
- Filter out scopes with `pending_approval` status from the main scopes list
- Ensure the user's current scope is always included in `scopeOptions` if it exists and isn't already in the filtered list
- Simplified error handling by consolidating the fallback logic into a single catch block
- Improved robustness when the main scopes API call fails by still providing the user's current scope as a fallback

## Implementation Details
- The user's scope is now fetched independently and stored in `meScope` before attempting to fetch the full scopes list
- If the main scopes fetch succeeds, the user's scope is added to the list only if it's not already present (avoiding duplicates)
- If the main scopes fetch fails, the function falls back to using just the user's current scope if available
- This ensures users always have access to their current scope in the dropdown, even in edge cases where it might not be returned by the main scopes endpoint

https://claude.ai/code/session_013Df29PUfJmAtRkAjfTiNcg