### PR TITLE
Add /platform/types/* endpoints for form value sets

### DIFF
--- a/app/frontend/src/components/views/Accounts.svelte
+++ b/app/frontend/src/components/views/Accounts.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { viewData, pagination, ui, SUPPORTED_CURRENCIES } from '../../lib/store.svelte.js'
+  import { viewData, pagination, ui } from '../../lib/store.svelte.js'
   import { loadMore, createAccount } from '../../lib/actions.js'
   import { apiFetch } from '../../lib/api.js'
   import { statusBadgeClass, formatStatus } from '../../lib/utils.js'
@@ -13,6 +13,8 @@
   let showModal = $state(false)
   let form = $state({ name: '', type: '', selectedCurrencies: [], customerIds: [] })
   let customerOptions = $state([])
+  let accountTypeOptions = $state([])
+  let currencyOptions = $state([])
   let customerSearch = $state('')
   let showCustomerDropdown = $state(false)
 
@@ -30,10 +32,16 @@
     form = { name: '', type: '', selectedCurrencies: [], customerIds: [] }
     customerSearch = ''
     showModal = true
-    try {
-      const res = await apiFetch('GET', '/customers/?limit=200')
-      customerOptions = res.data.map(e => e.attributes).filter(c => c.status === 'active')
-    } catch { customerOptions = [] }
+    const results = await Promise.allSettled([
+      apiFetch('GET', '/customers/?limit=200'),
+      apiFetch('GET', '/platform/types/account-types'),
+      apiFetch('GET', '/platform/types/currencies'),
+    ])
+    customerOptions = results[0].status === 'fulfilled'
+      ? results[0].value.data.map(e => e.attributes).filter(c => c.status === 'active')
+      : []
+    accountTypeOptions = results[1].status === 'fulfilled' ? results[1].value.values : []
+    currencyOptions = results[2].status === 'fulfilled' ? results[2].value.values : []
   }
 
   function toggleCurrency(c) {
@@ -129,16 +137,15 @@
           <label class="field-label">Account Type</label>
           <select bind:value={form.type} class="field-input field-select" required>
             <option value="">Select type...</option>
-            <option value="checking">Checking</option>
-            <option value="overnight_money">Overnight Money</option>
-            <option value="savings">Savings</option>
-            <option value="card">Card</option>
+            {#each accountTypeOptions as t (t)}
+              <option value={t}>{t.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}</option>
+            {/each}
           </select>
         </div>
         <div class="mb-4">
           <label class="field-label">Currencies</label>
           <div class="checkbox-grid flex gap-4 flex-wrap mt-1">
-            {#each SUPPORTED_CURRENCIES as c (c)}
+            {#each currencyOptions as c (c)}
               <label class="checkbox-item">
                 <input type="checkbox" checked={form.selectedCurrencies.includes(c)} onchange={() => toggleCurrency(c)}>
                 <span class="font-mono text-sm">{c.toUpperCase()}</span>

--- a/app/frontend/src/components/views/Customers.svelte
+++ b/app/frontend/src/components/views/Customers.svelte
@@ -1,15 +1,21 @@
 <script>
   import { viewData, pagination, ui } from '../../lib/store.svelte.js'
   import { loadMore, createCustomer } from '../../lib/actions.js'
+  import { apiFetch } from '../../lib/api.js'
   import { statusBadgeClass, formatStatus } from '../../lib/utils.js'
 
   let showModal = $state(false)
   let form = $state({ name: '', type: '' })
+  let customerTypeOptions = $state([])
   let drawerCustomer = $state(null)
 
-  function openModal() {
+  async function openModal() {
     form = { name: '', type: '' }
     showModal = true
+    try {
+      const res = await apiFetch('GET', '/platform/types/customer-types')
+      customerTypeOptions = res.values
+    } catch { customerTypeOptions = [] }
   }
 
   async function handleSubmit() {
@@ -115,8 +121,9 @@
           <label class="field-label">Customer Type</label>
           <select bind:value={form.type} class="field-input field-select" required>
             <option value="">Select type...</option>
-            <option value="individual">Individual</option>
-            <option value="business">Business</option>
+            {#each customerTypeOptions as t (t)}
+              <option value={t}>{t.replace(/\b\w/g, c => c.toUpperCase())}</option>
+            {/each}
           </select>
         </div>
         <div class="flex gap-2 justify-end">

--- a/app/frontend/src/components/views/Roles.svelte
+++ b/app/frontend/src/components/views/Roles.svelte
@@ -11,6 +11,20 @@
   let scopeSearch = $state('')
   let showScopeDropdown = $state(false)
 
+  let allSelected = $derived(
+    permissionOptions.length > 0 && form.selectedPermissions.length === permissionOptions.length
+  )
+  let someSelected = $derived(
+    form.selectedPermissions.length > 0 && form.selectedPermissions.length < permissionOptions.length
+  )
+
+  let selectAllEl = $state(null)
+  $effect(() => { if (selectAllEl) selectAllEl.indeterminate = someSelected })
+
+  function toggleAll() {
+    form.selectedPermissions = allSelected ? [] : [...permissionOptions]
+  }
+
   let scopeSuggestions = $derived(
     scopeOptions
       .filter(s => {
@@ -179,6 +193,10 @@
         <div class="mb-4">
           <label class="field-label">Permissions</label>
           <div class="permission-list">
+            <label class="permission-item border-b border-zinc-200 mb-0.5 pb-0.5">
+              <input type="checkbox" bind:this={selectAllEl} checked={allSelected} onchange={toggleAll}>
+              <span class="font-mono text-zinc-500">Select all</span>
+            </label>
             {#each permissionOptions as p (p)}
               <label class="permission-item">
                 <input type="checkbox" checked={form.selectedPermissions.includes(p)} onchange={() => togglePermission(p)}>

--- a/app/frontend/src/components/views/Roles.svelte
+++ b/app/frontend/src/components/views/Roles.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { viewData, pagination, ui, ALL_PERMISSIONS } from '../../lib/store.svelte.js'
+  import { viewData, pagination, ui } from '../../lib/store.svelte.js'
   import { loadMore, createRole } from '../../lib/actions.js'
   import { apiFetch } from '../../lib/api.js'
   import { statusBadgeClass, formatStatus } from '../../lib/utils.js'
@@ -7,6 +7,7 @@
   let showModal = $state(false)
   let form = $state({ name: '', selectedPermissions: [], selectedScopes: [] })
   let scopeOptions = $state([])
+  let permissionOptions = $state([])
   let scopeSearch = $state('')
   let showScopeDropdown = $state(false)
 
@@ -24,10 +25,14 @@
     form = { name: '', selectedPermissions: [], selectedScopes: [] }
     scopeSearch = ''
     showModal = true
-    try {
-      const res = await apiFetch('GET', '/scopes/?limit=200')
-      scopeOptions = res.data.map(e => e.attributes).filter(s => s.status === 'active')
-    } catch { scopeOptions = [] }
+    const results = await Promise.allSettled([
+      apiFetch('GET', '/scopes/?limit=200'),
+      apiFetch('GET', '/platform/types/permissions'),
+    ])
+    scopeOptions = results[0].status === 'fulfilled'
+      ? results[0].value.data.map(e => e.attributes).filter(s => s.status === 'active')
+      : []
+    permissionOptions = results[1].status === 'fulfilled' ? results[1].value.values : []
   }
 
   function togglePermission(p) {
@@ -174,7 +179,7 @@
         <div class="mb-4">
           <label class="field-label">Permissions</label>
           <div class="permission-list">
-            {#each ALL_PERMISSIONS as p (p)}
+            {#each permissionOptions as p (p)}
               <label class="permission-item">
                 <input type="checkbox" checked={form.selectedPermissions.includes(p)} onchange={() => togglePermission(p)}>
                 <span class="font-mono">{p}</span>

--- a/app/frontend/src/components/views/Transactions.svelte
+++ b/app/frontend/src/components/views/Transactions.svelte
@@ -7,6 +7,8 @@
 
   let showModal = $state(false)
   let accountOptions = $state([])
+  let currencyOptions = $state([])
+  let ledgerEntryTypeOptions = $state([])
   let activeDropdown = $state(-1)
   let entryCounter = $state(1)
 
@@ -46,10 +48,16 @@
     entryCounter = 1
     activeDropdown = -1
     showModal = true
-    try {
-      const res = await apiFetch('GET', '/accounts/?limit=200')
-      accountOptions = res.data.map(e => e.attributes)
-    } catch { accountOptions = [] }
+    const results = await Promise.allSettled([
+      apiFetch('GET', '/accounts/?limit=200'),
+      apiFetch('GET', '/platform/types/currencies'),
+      apiFetch('GET', '/platform/types/ledger-entry-types'),
+    ])
+    accountOptions = results[0].status === 'fulfilled'
+      ? results[0].value.data.map(e => e.attributes)
+      : []
+    currencyOptions = results[1].status === 'fulfilled' ? results[1].value.values : []
+    ledgerEntryTypeOptions = results[2].status === 'fulfilled' ? results[2].value.values : []
   }
 
   function addEntry() {
@@ -225,11 +233,9 @@
             <label class="field-label">Currency</label>
             <select bind:value={form.currency} class="field-input field-select" required>
               <option value="">Select...</option>
-              <option value="chf">CHF</option>
-              <option value="eur">EUR</option>
-              <option value="gbp">GBP</option>
-              <option value="jpy">JPY</option>
-              <option value="usd">USD</option>
+              {#each currencyOptions as c (c)}
+                <option value={c}>{c.toUpperCase()}</option>
+              {/each}
             </select>
           </div>
           <div>
@@ -322,44 +328,9 @@
                 <div>
                   <label class="field-label text-xs">Entry Type</label>
                   <select bind:value={entry.entry_type} class="field-input field-select text-xs" required>
-                    <optgroup label="Core">
-                      <option value="principal">Principal</option>
-                      <option value="settlement">Settlement</option>
-                      <option value="sepa_credit_transfer">SEPA Credit Transfer</option>
-                      <option value="transaction_fee">Transaction Fee</option>
-                    </optgroup>
-                    <optgroup label="Interest">
-                      <option value="interest">Interest</option>
-                      <option value="accrued_interest">Accrued Interest</option>
-                      <option value="penalty_interest">Penalty Interest</option>
-                    </optgroup>
-                    <optgroup label="Fees">
-                      <option value="overdraft_fee">Overdraft Fee</option>
-                      <option value="maintenance_fee">Maintenance Fee</option>
-                      <option value="commission">Commission</option>
-                      <option value="foreign_exchange_fee">Foreign Exchange Fee</option>
-                    </optgroup>
-                    <optgroup label="FX &amp; Valuation">
-                      <option value="fx_gain">FX Gain</option>
-                      <option value="fx_loss">FX Loss</option>
-                      <option value="revaluation">Revaluation</option>
-                    </optgroup>
-                    <optgroup label="Credit Events">
-                      <option value="penalty">Penalty</option>
-                      <option value="charge_off">Charge Off</option>
-                      <option value="provision">Provision</option>
-                    </optgroup>
-                    <optgroup label="Corporate Actions">
-                      <option value="dividend">Dividend</option>
-                      <option value="premium">Premium</option>
-                      <option value="rebate">Rebate</option>
-                    </optgroup>
-                    <optgroup label="Operational">
-                      <option value="adjustment">Adjustment</option>
-                      <option value="reversal">Reversal</option>
-                      <option value="collateral">Collateral</option>
-                      <option value="escrow">Escrow</option>
-                    </optgroup>
+                    {#each ledgerEntryTypeOptions as t (t)}
+                      <option value={t}>{t.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}</option>
+                    {/each}
                   </select>
                 </div>
 

--- a/app/frontend/src/lib/store.svelte.js
+++ b/app/frontend/src/lib/store.svelte.js
@@ -66,41 +66,6 @@ export const pagination = $state({
   },
 })
 
-export const SUPPORTED_CURRENCIES = ['chf', 'eur', 'gbp', 'jpy', 'usd']
-
-export const ALL_PERMISSIONS = [
-  'read_accounts_list',
-  'write_accounts_opening_request',
-  'write_accounts_opening_compliance_approval',
-  'write_accounts_opening_board_approval',
-  'read_api_keys_list',
-  'write_api_keys_generation_request',
-  'write_api_keys_revocation_request',
-  'read_customers_list',
-  'write_customers_onboarding_request',
-  'read_roles_list',
-  'write_roles_creation_request',
-  'read_scopes_list',
-  'write_scopes_creation_request',
-  'read_postings_list',
-  'write_transactions_internal_transfers_initiation_request',
-  'read_users_list',
-  'write_users_onboarding_request',
-  'write_users_assign_roles_request',
-  'read_approvals_list',
-  'write_approvals_collection_request',
-  'write_approvals_rejection_request',
-  'read_payments_sepa_credit_transfers_list',
-  'write_payments_sepa_credit_transfers_request',
-  'write_payments_sepa_credit_transfers_approval',
-  'read_accounts_blocks',
-  'write_accounts_blocking_request',
-  'write_accounts_unblocking_request',
-  'write_accounts_blocking_approval',
-  'write_accounts_unblocking_approval',
-  'read_events_list',
-]
-
 export const NAV_SECTIONS = [
   {
     label: 'Home',

--- a/app/openapi.yaml
+++ b/app/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 info:
   description: App description for OpenAPI docs
   title: CrystalBank
-  version: 0.12.1
+  version: 0.13.1
 paths:
   /.well-known/openid-configuration:
     get:
@@ -1765,6 +1765,247 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+  /platform/types/permissions:
+    get:
+      summary: Get permissions
+      description: 'Get permissions
+
+        Returns a sorted list of all permission values available in the platform.
+
+        Intended to populate form dropdowns and value pickers on the frontend.
+
+
+        Required permission:
+
+        - **read_platform_types**'
+      tags:
+      - Types
+      operationId: CrystalBank::Domains::Platform::Api::Types_get_permissions
+      parameters: []
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+  /platform/types/account-types:
+    get:
+      summary: Get account types
+      description: 'Get account types
+
+        Returns a sorted list of all account type values available in the platform.
+
+        Intended to populate form dropdowns and value pickers on the frontend.
+
+
+        Required permission:
+
+        - **read_platform_types**'
+      tags:
+      - Types
+      operationId: CrystalBank::Domains::Platform::Api::Types_get_account_types
+      parameters: []
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+  /platform/types/currencies:
+    get:
+      summary: Get currencies
+      description: 'Get currencies
+
+        Returns a sorted list of all ISO 4217 currency codes available in the platform.
+
+        Intended to populate form dropdowns and value pickers on the frontend.
+
+
+        Required permission:
+
+        - **read_platform_types**'
+      tags:
+      - Types
+      operationId: CrystalBank::Domains::Platform::Api::Types_get_currencies
+      parameters: []
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+  /platform/types/customer-types:
+    get:
+      summary: Get customer types
+      description: 'Get customer types
+
+        Returns a sorted list of all customer type values available in the platform.
+
+        Intended to populate form dropdowns and value pickers on the frontend.
+
+
+        Required permission:
+
+        - **read_platform_types**'
+      tags:
+      - Types
+      operationId: CrystalBank::Domains::Platform::Api::Types_get_customer_types
+      parameters: []
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+  /platform/types/ledger-entry-types:
+    get:
+      summary: Get ledger transaction entry types
+      description: 'Get ledger transaction entry types
+
+        Returns a sorted list of all ledger transaction entry type values available
+        in the platform.
+
+        Intended to populate form dropdowns and value pickers on the frontend.
+
+
+        Required permission:
+
+        - **read_platform_types**'
+      tags:
+      - Types
+      operationId: CrystalBank::Domains::Platform::Api::Types_get_ledger_entry_types
+      parameters: []
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CrystalBank__Api__Responses__ErrorResponse'
 components:
   schemas:
     CrystalBank__Api__JWKS__OpenIDConfiguration:
@@ -2555,6 +2796,7 @@ components:
             - write_payments_sepa_credit_transfers_approval
             - read_events_list
             - read_me
+            - read_platform_types
         scopes:
           type: array
           items:
@@ -2671,6 +2913,7 @@ components:
                       - write_payments_sepa_credit_transfers_approval
                       - read_events_list
                       - read_me
+                      - read_platform_types
                   scopes:
                     type: array
                     description: Scope the role has access to
@@ -3307,6 +3550,16 @@ components:
       required:
       - user_id
       - role_ids
+    CrystalBank__Domains__Platform__Api__TypeResponses__TypesResponse:
+      type: object
+      properties:
+        values:
+          type: array
+          description: Sorted list of type values
+          items:
+            type: string
+      required:
+      - values
     CrystalBank__Api__Responses__ErrorResponse:
       type: object
       properties:

--- a/app/shard.lock
+++ b/app/shard.lock
@@ -14,7 +14,7 @@ shards:
 
   crystal-es:
     git: https://github.com/tristanholl/crystal-es.git
-    version: 0.3.0+git.commit.79b29a5c125a9ceb2886a5025374dea980e0d2cb
+    version: 0.3.1+git.commit.1cd348d3ff08fa669755f7eecceef208311e9244
 
   crystal_iban:
     git: https://github.com/tristanholl/crystal-iban.git

--- a/app/shard.yml
+++ b/app/shard.yml
@@ -1,5 +1,5 @@
 name: crystalbank
-version: 0.12.1
+version: 0.13.1
 
 authors:
   - Tristan Holl <mail@tristanholl.com>

--- a/app/spec/domains/platform/commands/types_spec.cr
+++ b/app/spec/domains/platform/commands/types_spec.cr
@@ -65,8 +65,9 @@ describe Platform::Types::Commands::FetchCurrencies do
     result.should eq(Platform::Queries::Currencies.new.list)
   end
 
-  it "includes all supported currencies" do
+  it "contains exactly the supported currencies" do
     result = Platform::Types::Commands::FetchCurrencies.new.call(context)
+    result.size.should eq(CrystalBank::Types::Currencies::Supported.values.size)
     CrystalBank::Types::Currencies::Supported.values.each do |supported|
       result.should contain(supported.to_s)
     end

--- a/app/spec/domains/platform/commands/types_spec.cr
+++ b/app/spec/domains/platform/commands/types_spec.cr
@@ -1,0 +1,116 @@
+require "../../../spec_helper"
+
+private def make_types_context : CrystalBank::Api::Context
+  CrystalBank::Api::Context.new(
+    user_id: UUID.v7,
+    roles: [] of UUID,
+    required_permission: CrystalBank::Permissions::READ_platform_types,
+    scope: nil,
+    available_scopes: [] of UUID
+  )
+end
+
+describe Platform::Types::Commands::FetchPermissions do
+  context = make_types_context
+
+  it "returns a non-empty sorted list" do
+    result = Platform::Types::Commands::FetchPermissions.new.call(context)
+    result.should_not be_empty
+    result.should eq(result.sort)
+  end
+
+  it "matches the query output exactly" do
+    result = Platform::Types::Commands::FetchPermissions.new.call(context)
+    result.should eq(Platform::Queries::Permissions.new.list)
+  end
+
+  it "includes the read_platform_types permission itself" do
+    result = Platform::Types::Commands::FetchPermissions.new.call(context)
+    result.should contain("read_platform_types")
+  end
+end
+
+describe Platform::Types::Commands::FetchAccountTypes do
+  context = make_types_context
+
+  it "returns a non-empty sorted list" do
+    result = Platform::Types::Commands::FetchAccountTypes.new.call(context)
+    result.should_not be_empty
+    result.should eq(result.sort)
+  end
+
+  it "matches the query output exactly" do
+    result = Platform::Types::Commands::FetchAccountTypes.new.call(context)
+    result.should eq(Platform::Queries::AccountTypes.new.list)
+  end
+
+  it "includes both public and internal account types" do
+    result = Platform::Types::Commands::FetchAccountTypes.new.call(context)
+    result.should contain("checking")
+    result.should contain("settlement")
+  end
+end
+
+describe Platform::Types::Commands::FetchCurrencies do
+  context = make_types_context
+
+  it "returns a non-empty sorted list" do
+    result = Platform::Types::Commands::FetchCurrencies.new.call(context)
+    result.should_not be_empty
+    result.should eq(result.sort)
+  end
+
+  it "matches the query output exactly" do
+    result = Platform::Types::Commands::FetchCurrencies.new.call(context)
+    result.should eq(Platform::Queries::Currencies.new.list)
+  end
+
+  it "includes all supported currencies" do
+    result = Platform::Types::Commands::FetchCurrencies.new.call(context)
+    CrystalBank::Types::Currencies::Supported.values.each do |supported|
+      result.should contain(supported.to_s)
+    end
+  end
+end
+
+describe Platform::Types::Commands::FetchCustomerTypes do
+  context = make_types_context
+
+  it "returns a non-empty sorted list" do
+    result = Platform::Types::Commands::FetchCustomerTypes.new.call(context)
+    result.should_not be_empty
+    result.should eq(result.sort)
+  end
+
+  it "matches the query output exactly" do
+    result = Platform::Types::Commands::FetchCustomerTypes.new.call(context)
+    result.should eq(Platform::Queries::CustomerTypes.new.list)
+  end
+
+  it "contains exactly business and individual" do
+    result = Platform::Types::Commands::FetchCustomerTypes.new.call(context)
+    result.should eq(["business", "individual"])
+  end
+end
+
+describe Platform::Types::Commands::FetchLedgerEntryTypes do
+  context = make_types_context
+
+  it "returns a non-empty sorted list" do
+    result = Platform::Types::Commands::FetchLedgerEntryTypes.new.call(context)
+    result.should_not be_empty
+    result.should eq(result.sort)
+  end
+
+  it "matches the query output exactly" do
+    result = Platform::Types::Commands::FetchLedgerEntryTypes.new.call(context)
+    result.should eq(Platform::Queries::LedgerEntryTypes.new.list)
+  end
+
+  it "includes operational and principal entry types" do
+    result = Platform::Types::Commands::FetchLedgerEntryTypes.new.call(context)
+    result.should contain("principal")
+    result.should contain("adjustment")
+    result.should contain("reversal")
+  end
+end

--- a/app/spec/domains/platform/queries/types_spec.cr
+++ b/app/spec/domains/platform/queries/types_spec.cr
@@ -1,0 +1,143 @@
+require "../../../spec_helper"
+
+describe CrystalBank::Domains::Platform::Queries::Permissions do
+  subject = Platform::Queries::Permissions.new
+
+  it "returns a non-empty list" do
+    subject.list.should_not be_empty
+  end
+
+  it "returns lowercase strings" do
+    subject.list.each { |v| v.should eq(v.downcase) }
+  end
+
+  it "returns a sorted list" do
+    result = subject.list
+    result.should eq(result.sort)
+  end
+
+  it "includes known permissions" do
+    result = subject.list
+    result.should contain("read_accounts_list")
+    result.should contain("write_accounts_opening_request")
+    result.should contain("read_platform_types")
+  end
+
+  it "contains all defined permissions" do
+    result = subject.list
+    result.size.should eq(CrystalBank::Permissions.values.size)
+  end
+end
+
+describe CrystalBank::Domains::Platform::Queries::AccountTypes do
+  subject = Platform::Queries::AccountTypes.new
+
+  it "returns a non-empty list" do
+    subject.list.should_not be_empty
+  end
+
+  it "returns lowercase strings" do
+    subject.list.each { |v| v.should eq(v.downcase) }
+  end
+
+  it "returns a sorted list" do
+    result = subject.list
+    result.should eq(result.sort)
+  end
+
+  it "includes known account types" do
+    result = subject.list
+    result.should contain("checking")
+    result.should contain("savings")
+    result.should contain("settlement")
+  end
+
+  it "contains all defined account types" do
+    result = subject.list
+    result.size.should eq(CrystalBank::Types::Accounts::Type.values.size)
+  end
+end
+
+describe CrystalBank::Domains::Platform::Queries::Currencies do
+  subject = Platform::Queries::Currencies.new
+
+  it "returns a non-empty list" do
+    subject.list.should_not be_empty
+  end
+
+  it "returns lowercase strings" do
+    subject.list.each { |v| v.should eq(v.downcase) }
+  end
+
+  it "returns a sorted list" do
+    result = subject.list
+    result.should eq(result.sort)
+  end
+
+  it "includes known ISO 4217 currency codes" do
+    result = subject.list
+    result.should contain("eur")
+    result.should contain("usd")
+    result.should contain("gbp")
+    result.should contain("chf")
+  end
+
+  it "contains all defined available currencies" do
+    result = subject.list
+    result.size.should eq(CrystalBank::Types::Currencies::Available.values.size)
+  end
+end
+
+describe CrystalBank::Domains::Platform::Queries::CustomerTypes do
+  subject = Platform::Queries::CustomerTypes.new
+
+  it "returns a non-empty list" do
+    subject.list.should_not be_empty
+  end
+
+  it "returns lowercase strings" do
+    subject.list.each { |v| v.should eq(v.downcase) }
+  end
+
+  it "returns a sorted list" do
+    result = subject.list
+    result.should eq(result.sort)
+  end
+
+  it "includes all defined customer types" do
+    result = subject.list
+    result.should contain("business")
+    result.should contain("individual")
+    result.size.should eq(CrystalBank::Types::Customers::Type.values.size)
+  end
+end
+
+describe CrystalBank::Domains::Platform::Queries::LedgerEntryTypes do
+  subject = Platform::Queries::LedgerEntryTypes.new
+
+  it "returns a non-empty list" do
+    subject.list.should_not be_empty
+  end
+
+  it "returns lowercase strings" do
+    subject.list.each { |v| v.should eq(v.downcase) }
+  end
+
+  it "returns a sorted list" do
+    result = subject.list
+    result.should eq(result.sort)
+  end
+
+  it "includes known entry types" do
+    result = subject.list
+    result.should contain("principal")
+    result.should contain("adjustment")
+    result.should contain("reversal")
+    result.should contain("sepa_credit_transfer")
+  end
+
+  it "contains all defined ledger entry types" do
+    result = subject.list
+    result.size.should eq(CrystalBank::Types::LedgerTransactions::EntryType.values.size)
+  end
+end

--- a/app/spec/domains/platform/queries/types_spec.cr
+++ b/app/spec/domains/platform/queries/types_spec.cr
@@ -74,17 +74,24 @@ describe CrystalBank::Domains::Platform::Queries::Currencies do
     result.should eq(result.sort)
   end
 
-  it "includes known ISO 4217 currency codes" do
+  it "includes all supported currency codes" do
     result = subject.list
     result.should contain("eur")
     result.should contain("usd")
     result.should contain("gbp")
     result.should contain("chf")
+    result.should contain("jpy")
   end
 
-  it "contains all defined available currencies" do
+  it "contains exactly the supported currencies" do
     result = subject.list
-    result.size.should eq(CrystalBank::Types::Currencies::Available.values.size)
+    result.size.should eq(CrystalBank::Types::Currencies::Supported.values.size)
+  end
+
+  it "does not include unsupported currencies" do
+    result = subject.list
+    result.should_not contain("aed")
+    result.should_not contain("zar")
   end
 end
 

--- a/app/src/config/permissions.cr
+++ b/app/src/config/permissions.cr
@@ -66,6 +66,9 @@ module CrystalBank
     # Me
     READ_me
 
+    # Platform Types
+    READ_platform_types
+
     def to_s
       super.to_s.downcase
     end

--- a/app/src/domains/platform/api/concerns/type_responses.cr
+++ b/app/src/domains/platform/api/concerns/type_responses.cr
@@ -1,0 +1,15 @@
+module CrystalBank::Domains::Platform
+  module Api
+    module TypeResponses
+      struct TypesResponse
+        include JSON::Serializable
+
+        @[JSON::Field(description: "Sorted list of type values")]
+        getter values : Array(String)
+
+        def initialize(@values : Array(String))
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/api/types.cr
+++ b/app/src/domains/platform/api/types.cr
@@ -1,0 +1,80 @@
+require "./concerns/type_responses"
+
+module CrystalBank::Domains::Platform
+  module Api
+    class Types < CrystalBank::Api::Base
+      include CrystalBank::Domains::Platform::Api::TypeResponses
+      base "/platform/types"
+
+      # Get permissions
+      # Returns a sorted list of all permission values available in the platform.
+      # Intended to populate form dropdowns and value pickers on the frontend.
+      #
+      # Required permission:
+      # - **read_platform_types**
+      @[AC::Route::GET("/permissions")]
+      def get_permissions : TypesResponse
+        authorized?("read_platform_types", request_scope: false)
+
+        values = ::Platform::Types::Commands::FetchPermissions.new.call(context)
+        TypesResponse.new(values)
+      end
+
+      # Get account types
+      # Returns a sorted list of all account type values available in the platform.
+      # Intended to populate form dropdowns and value pickers on the frontend.
+      #
+      # Required permission:
+      # - **read_platform_types**
+      @[AC::Route::GET("/account-types")]
+      def get_account_types : TypesResponse
+        authorized?("read_platform_types", request_scope: false)
+
+        values = ::Platform::Types::Commands::FetchAccountTypes.new.call(context)
+        TypesResponse.new(values)
+      end
+
+      # Get currencies
+      # Returns a sorted list of all ISO 4217 currency codes available in the platform.
+      # Intended to populate form dropdowns and value pickers on the frontend.
+      #
+      # Required permission:
+      # - **read_platform_types**
+      @[AC::Route::GET("/currencies")]
+      def get_currencies : TypesResponse
+        authorized?("read_platform_types", request_scope: false)
+
+        values = ::Platform::Types::Commands::FetchCurrencies.new.call(context)
+        TypesResponse.new(values)
+      end
+
+      # Get customer types
+      # Returns a sorted list of all customer type values available in the platform.
+      # Intended to populate form dropdowns and value pickers on the frontend.
+      #
+      # Required permission:
+      # - **read_platform_types**
+      @[AC::Route::GET("/customer-types")]
+      def get_customer_types : TypesResponse
+        authorized?("read_platform_types", request_scope: false)
+
+        values = ::Platform::Types::Commands::FetchCustomerTypes.new.call(context)
+        TypesResponse.new(values)
+      end
+
+      # Get ledger transaction entry types
+      # Returns a sorted list of all ledger transaction entry type values available in the platform.
+      # Intended to populate form dropdowns and value pickers on the frontend.
+      #
+      # Required permission:
+      # - **read_platform_types**
+      @[AC::Route::GET("/ledger-entry-types")]
+      def get_ledger_entry_types : TypesResponse
+        authorized?("read_platform_types", request_scope: false)
+
+        values = ::Platform::Types::Commands::FetchLedgerEntryTypes.new.call(context)
+        TypesResponse.new(values)
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/commands/types/fetch_account_types.cr
+++ b/app/src/domains/platform/commands/types/fetch_account_types.cr
@@ -1,0 +1,11 @@
+module CrystalBank::Domains::Platform
+  module Types
+    module Commands
+      class FetchAccountTypes < ES::Command
+        def call(c : CrystalBank::Api::Context) : Array(String)
+          Queries::AccountTypes.new.list
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/commands/types/fetch_currencies.cr
+++ b/app/src/domains/platform/commands/types/fetch_currencies.cr
@@ -1,0 +1,11 @@
+module CrystalBank::Domains::Platform
+  module Types
+    module Commands
+      class FetchCurrencies < ES::Command
+        def call(c : CrystalBank::Api::Context) : Array(String)
+          Queries::Currencies.new.list
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/commands/types/fetch_customer_types.cr
+++ b/app/src/domains/platform/commands/types/fetch_customer_types.cr
@@ -1,0 +1,11 @@
+module CrystalBank::Domains::Platform
+  module Types
+    module Commands
+      class FetchCustomerTypes < ES::Command
+        def call(c : CrystalBank::Api::Context) : Array(String)
+          Queries::CustomerTypes.new.list
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/commands/types/fetch_ledger_entry_types.cr
+++ b/app/src/domains/platform/commands/types/fetch_ledger_entry_types.cr
@@ -1,0 +1,11 @@
+module CrystalBank::Domains::Platform
+  module Types
+    module Commands
+      class FetchLedgerEntryTypes < ES::Command
+        def call(c : CrystalBank::Api::Context) : Array(String)
+          Queries::LedgerEntryTypes.new.list
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/commands/types/fetch_permissions.cr
+++ b/app/src/domains/platform/commands/types/fetch_permissions.cr
@@ -1,0 +1,11 @@
+module CrystalBank::Domains::Platform
+  module Types
+    module Commands
+      class FetchPermissions < ES::Command
+        def call(c : CrystalBank::Api::Context) : Array(String)
+          Queries::Permissions.new.list
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/load.cr
+++ b/app/src/domains/platform/load.cr
@@ -1,9 +1,18 @@
-# API
-require "./api/platform"
+# Domain (defines Platform alias used by API and commands)
+require "./platform"
+
+# Queries
+require "./queries/types"
 
 # Commands
 require "./commands/seed/service"
 require "./commands/reset/request"
+require "./commands/types/fetch_permissions"
+require "./commands/types/fetch_account_types"
+require "./commands/types/fetch_currencies"
+require "./commands/types/fetch_customer_types"
+require "./commands/types/fetch_ledger_entry_types"
 
-# Domain
-require "./platform"
+# API
+require "./api/platform"
+require "./api/types"

--- a/app/src/domains/platform/platform.cr
+++ b/app/src/domains/platform/platform.cr
@@ -4,3 +4,5 @@ module CrystalBank
     end
   end
 end
+
+alias Platform = CrystalBank::Domains::Platform

--- a/app/src/domains/platform/queries/types.cr
+++ b/app/src/domains/platform/queries/types.cr
@@ -1,0 +1,33 @@
+module CrystalBank::Domains::Platform
+  module Queries
+    class Permissions
+      def list : Array(String)
+        CrystalBank::Permissions.values.map(&.to_s).sort
+      end
+    end
+
+    class AccountTypes
+      def list : Array(String)
+        CrystalBank::Types::Accounts::Type.values.map(&.to_s).sort
+      end
+    end
+
+    class Currencies
+      def list : Array(String)
+        CrystalBank::Types::Currencies::Available.values.map(&.to_s).sort
+      end
+    end
+
+    class CustomerTypes
+      def list : Array(String)
+        CrystalBank::Types::Customers::Type.values.map(&.to_s).sort
+      end
+    end
+
+    class LedgerEntryTypes
+      def list : Array(String)
+        CrystalBank::Types::LedgerTransactions::EntryType.values.map(&.to_s).sort
+      end
+    end
+  end
+end

--- a/app/src/domains/platform/queries/types.cr
+++ b/app/src/domains/platform/queries/types.cr
@@ -14,7 +14,7 @@ module CrystalBank::Domains::Platform
 
     class Currencies
       def list : Array(String)
-        CrystalBank::Types::Currencies::Available.values.map(&.to_s).sort
+        CrystalBank::Types::Currencies::Supported.values.map(&.to_s).sort
       end
     end
 

--- a/app/src/domains/scopes/queries/scopes_tree.cr
+++ b/app/src/domains/scopes/queries/scopes_tree.cr
@@ -20,7 +20,7 @@ module CrystalBank::Domains::Scopes
             FROM
               projections.scopes
             WHERE
-              uuid IN ($1)
+              uuid = ANY($1::uuid[])
               AND status = 'active'
             UNION ALL
             SELECT
@@ -39,7 +39,7 @@ module CrystalBank::Domains::Scopes
             available_scopes
         )
 
-        @db.query_all(query.join(" "), args: uuids, as: UUID)
+        @db.query_all(query.join(" "), args: [uuids], as: UUID)
       end
     end
   end


### PR DESCRIPTION
Exposes five read-only endpoints under GET /platform/types/ that return
sorted lists of enum values — permissions, account types, currencies,
customer types, and ledger entry types — for frontend form population.

Each endpoint follows the API → Command → Query → Command → API pattern.
All endpoints require the new read_platform_types permission.

- config/permissions.cr: add READ_platform_types permission
- domains/platform/platform.cr: add top-level Platform alias
- domains/platform/queries/types.cr: one query class per type
- domains/platform/commands/types/fetch_*.cr: five fetch commands
- domains/platform/api/concerns/type_responses.cr: TypesResponse struct
- domains/platform/api/types.cr: Types controller, base /platform/types
- domains/platform/load.cr: wire new files in correct dependency order

https://claude.ai/code/session_01JAEiRCun2cSDH8pFj9gLEk