### PR TITLE
Fix child_scopes query to support multiple UUID parameters

### DIFF
--- a/app/src/domains/scopes/queries/scopes_tree.cr
+++ b/app/src/domains/scopes/queries/scopes_tree.cr
@@ -20,7 +20,7 @@ module CrystalBank::Domains::Scopes
             FROM
               projections.scopes
             WHERE
-              uuid IN ($1)
+              uuid = ANY($1::uuid[])
               AND status = 'active'
             UNION ALL
             SELECT


### PR DESCRIPTION
Replace IN ($1) with = ANY($1::uuid[]) so the array of UUIDs is passed as a single PostgreSQL array parameter, matching the pattern used in roles_permissions.cr.

https://claude.ai/code/session_013YzDjsaRJDg2HYKcZpxifL