### PR TITLE
Set scope_id to its own UUID on scope creation

### DIFF
--- a/app/spec/domains/scopes/commands/creation/request_spec.cr
+++ b/app/spec/domains/scopes/commands/creation/request_spec.cr
@@ -28,7 +28,7 @@ describe CrystalBank::Domains::Scopes::Creation::Commands::Request do
 
     aggregate.state.name.should eq("Child Scope")
     aggregate.state.parent_scope_id.should eq(scope_id)
-    aggregate.state.scope_id.should eq(scope_id)
+    aggregate.state.scope_id.should eq(result)
   end
 
   it "creates a scope with an active parent scope" do
@@ -58,6 +58,7 @@ describe CrystalBank::Domains::Scopes::Creation::Commands::Request do
 
     aggregate.state.name.should eq("Child Scope")
     aggregate.state.parent_scope_id.should eq(parent_scope_id)
+    aggregate.state.scope_id.should eq(result)
   end
 
   it "raises when parent scope is not yet active (only requested, not accepted)" do

--- a/app/src/domains/scopes/commands/creation/request.cr
+++ b/app/src/domains/scopes/commands/creation/request.cr
@@ -20,13 +20,18 @@ module CrystalBank::Domains::Scopes
             raise CrystalBank::Exception::InvalidArgument.new("Parent scope is not active") unless aggregate.state.accepted
           end
 
+          # Generate the aggregate ID for the new scope upfront so scope_id can
+          # reference itself (the new scope belongs to itself)
+          aggregate_id = UUID.v7
+
           # Create the scope creation request event
           event = Scopes::Creation::Events::Requested.new(
             actor_id: actor,
             command_handler: self.class.to_s,
             name: r.name,
             parent_scope_id: parent_scope_id,
-            scope_id: scope,
+            scope_id: aggregate_id,
+            aggregate_id: aggregate_id,
           )
 
           # Append event to event store


### PR DESCRIPTION
When a scope is created, its scope_id now references itself (its own
aggregate UUID) rather than the requesting context's scope.

https://claude.ai/code/session_016XXnevJnASq2jARJi6KkMw