### PR TITLE
Show permission error dialog instead of logging out on 403

### DIFF
--- a/app/frontend/src/App.svelte
+++ b/app/frontend/src/App.svelte
@@ -18,6 +18,7 @@
   import Payments from './components/views/Payments.svelte'
   import SepaCreditTransfers from './components/views/SepaCreditTransfers.svelte'
   import Events from './components/views/Events.svelte'
+  import PermissionErrorDialog from './components/PermissionErrorDialog.svelte'
 
   const KNOWN_VIEWS = ['dashboard', 'accounts', 'customers', 'postings', 'users', 'roles', 'scopes', 'api_keys', 'approvals', 'payments', 'sepa_credit_transfers', 'events']
 
@@ -51,6 +52,7 @@
 </script>
 
 <ToastContainer />
+<PermissionErrorDialog />
 
 {#if !auth.token}
   <Login />

--- a/app/frontend/src/components/PermissionErrorDialog.svelte
+++ b/app/frontend/src/components/PermissionErrorDialog.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { ui } from '../lib/store.svelte.js'
+  import { logout, switchView } from '../lib/actions.js'
+
+  function goToDashboard() {
+    ui.permissionError = null
+    switchView('dashboard')
+  }
+
+  function handleLogout() {
+    ui.permissionError = null
+    logout()
+  }
+</script>
+
+{#if ui.permissionError}
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="perm-err-title">
+    <div class="modal-box" style="max-width: 420px;">
+      <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:0.75rem;">
+        <div style="flex-shrink:0; width:2.25rem; height:2.25rem; background:#fee2e2; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#b91c1c" stroke-width="2">
+            <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+        </div>
+        <h2 id="perm-err-title" class="modal-title" style="margin-bottom:0;">Permission Denied</h2>
+      </div>
+      <p class="modal-desc">{ui.permissionError}</p>
+      <p class="modal-desc" style="margin-top:-0.75rem;">Would you like to go to the dashboard or sign out?</p>
+      <div style="display:flex; gap:0.75rem; justify-content:flex-end;">
+        <button class="btn btn-ghost" onclick={handleLogout}>Sign out</button>
+        <button class="btn btn-primary" onclick={goToDashboard}>Go to Dashboard</button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/app/frontend/src/lib/api.js
+++ b/app/frontend/src/lib/api.js
@@ -1,4 +1,4 @@
-import { auth } from './store.svelte.js'
+import { auth, ui } from './store.svelte.js'
 
 // Injected at runtime by the Crystal server into window.__API_URL__.
 // Falls back to empty string so relative paths work in a Vite dev-server session.
@@ -26,6 +26,13 @@ export async function apiFetch(method, path, body = null, opts = {}) {
   if (res.status === 401) {
     clearSession()
     throw new Error('Session expired')
+  }
+
+  if (res.status === 403) {
+    let msg = 'You do not have permission to perform this action.'
+    try { const e = await res.json(); msg = e.message || msg } catch {}
+    ui.permissionError = msg
+    throw new Error(msg)
   }
 
   if (!res.ok) {

--- a/app/frontend/src/lib/store.svelte.js
+++ b/app/frontend/src/lib/store.svelte.js
@@ -15,6 +15,8 @@ export const ui = $state({
   toasts: [],
   /** @type {object|null} */
   selectedAccount: null,
+  /** @type {string|null} */
+  permissionError: null,
 })
 
 export const viewData = $state({

--- a/app/src/shared/api/base.cr
+++ b/app/src/shared/api/base.cr
@@ -35,7 +35,7 @@ module CrystalBank
       # Error handling
       # TODO: Annotation do not properly work when included from a module
       @[AC::Route::Exception(CrystalBank::Exception::Authentication, status_code: HTTP::Status::UNAUTHORIZED)]
-      @[AC::Route::Exception(CrystalBank::Exception::Authorization, status_code: HTTP::Status::UNAUTHORIZED)]
+      @[AC::Route::Exception(CrystalBank::Exception::Authorization, status_code: HTTP::Status::FORBIDDEN)]
       @[AC::Route::Exception(CrystalBank::Exception::InvalidArgument, status_code: HTTP::Status::BAD_REQUEST)]
       @[AC::Route::Exception(ES::Exception::NotFound, status_code: HTTP::Status::NOT_FOUND)]
       def error_reponse(error : ES::Exception::Error) : ErrorResponse


### PR DESCRIPTION
When a user lacks permission for an endpoint the backend previously
returned 401 (same as an expired token), causing the frontend to clear
the session and silently log the user out. This changes the backend to
return 403 for authorization failures and adds a PermissionErrorDialog
that lets the user choose to go to the dashboard or sign out.

https://claude.ai/code/session_014Jraz4gcTGDZtkbQCX1Y8n