### PR TITLE
Add account category field to accounts domain

### DIFF
--- a/app/src/config/types/accounts.cr
+++ b/app/src/config/types/accounts.cr
@@ -1,6 +1,17 @@
 module CrystalBank::Types::Accounts
   INTERNAL_TYPES = ["settlement", "nostro", "cpd", "frozen_funds"]
 
+  enum Category
+    Asset
+    Liability
+    Income
+    Expense
+
+    def to_s
+      super.to_s.downcase
+    end
+  end
+
   enum Type
     # Public account types
     Checking

--- a/app/src/domains/accounts/aggregates/account.cr
+++ b/app/src/domains/accounts/aggregates/account.cr
@@ -17,6 +17,7 @@ module CrystalBank::Domains::Accounts
       property supported_currencies = Array(CrystalBank::Types::Currencies::Supported).new
       property scope_id : UUID?
       property type : CrystalBank::Types::Accounts::Type?
+      property category : CrystalBank::Types::Accounts::Category?
       property requestor_id : UUID?
       property active_blocks = Array(CrystalBank::Types::Accounts::BlockType).new
       property closure_pending : Bool = false

--- a/app/src/domains/accounts/aggregates/opening.cr
+++ b/app/src/domains/accounts/aggregates/opening.cr
@@ -19,6 +19,7 @@ module CrystalBank::Domains::Accounts
           @state.supported_currencies = body.currencies
           @state.scope_id = body.scope_id
           @state.type = body.type
+          @state.category = body.category
           @state.customer_ids = body.customer_ids
           @state.requestor_id = event.header.actor_id
         end

--- a/app/src/domains/accounts/api/accounts.cr
+++ b/app/src/domains/accounts/api/accounts.cr
@@ -170,6 +170,7 @@ module CrystalBank::Domains::Accounts
             a.currencies,
             a.customer_ids,
             CrystalBank::Types::Accounts::Type.parse(a.type),
+            CrystalBank::Types::Accounts::Category.parse(a.category),
             a.status
           )
         end

--- a/app/src/domains/accounts/api/concerns/requests.cr
+++ b/app/src/domains/accounts/api/concerns/requests.cr
@@ -25,6 +25,9 @@ module CrystalBank::Domains::Accounts
 
         @[JSON::Field(description: "Type of the account")]
         getter type : CrystalBank::Types::Accounts::Type
+
+        @[JSON::Field(description: "Category of the account")]
+        getter category : CrystalBank::Types::Accounts::Category
       end
     end
   end

--- a/app/src/domains/accounts/api/concerns/responses.cr
+++ b/app/src/domains/accounts/api/concerns/responses.cr
@@ -58,6 +58,9 @@ module CrystalBank::Domains::Accounts
         @[JSON::Field(description: "Type of the account")]
         getter type : CrystalBank::Types::Accounts::Type
 
+        @[JSON::Field(description: "Category of the account")]
+        getter category : CrystalBank::Types::Accounts::Category
+
         @[JSON::Field(description: "Status of the account: active, pending_approval")]
         getter status : String
 
@@ -68,6 +71,7 @@ module CrystalBank::Domains::Accounts
           @currencies : Array(CrystalBank::Types::Currencies::Supported),
           @customer_ids : Array(UUID),
           @type : CrystalBank::Types::Accounts::Type,
+          @category : CrystalBank::Types::Accounts::Category,
           @status : String,
         ); end
       end

--- a/app/src/domains/accounts/commands/opening/request.cr
+++ b/app/src/domains/accounts/commands/opening/request.cr
@@ -26,7 +26,8 @@ module CrystalBank::Domains::Accounts
             currencies: r.currencies,
             customer_ids: r.customer_ids,
             scope_id: scope,
-            type: r.type
+            type: r.type,
+            category: r.category
           )
 
           # Append event to event store

--- a/app/src/domains/accounts/events/opening/requested.cr
+++ b/app/src/domains/accounts/events/opening/requested.cr
@@ -10,6 +10,7 @@ module CrystalBank::Domains::Accounts
           attribute :customer_ids, Array(UUID)
           attribute :scope_id, UUID
           attribute :type, CrystalBank::Types::Accounts::Type
+          attribute :category, CrystalBank::Types::Accounts::Category
         end
       end
     end

--- a/app/src/domains/accounts/projections/accounts.cr
+++ b/app/src/domains/accounts/projections/accounts.cr
@@ -18,6 +18,7 @@ module CrystalBank::Domains::Accounts
             "currencies" jsonb NOT NULL,
             "customer_ids" jsonb NOT NULL,
             "type" varchar NOT NULL,
+            "category" varchar NOT NULL,
             "status" varchar NOT NULL
           );
         )
@@ -46,11 +47,12 @@ module CrystalBank::Domains::Accounts
                 created_at,
                 name,
                 type,
+                category,
                 currencies,
                 customer_ids,
                 status
               )
-              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
           ),
             aggregate_id,
             aggregate_version,
@@ -58,6 +60,7 @@ module CrystalBank::Domains::Accounts
             created_at,
             body.name,
             body.type.to_s.downcase,
+            body.category.to_s.downcase,
             body.currencies.to_json,
             body.customer_ids.to_json,
             "pending_approval"

--- a/app/src/domains/accounts/queries/accounts.cr
+++ b/app/src/domains/accounts/queries/accounts.cr
@@ -19,6 +19,7 @@ module CrystalBank::Domains::Accounts
         getter customer_ids = Array(UUID).new
 
         getter type : String
+        getter category : String
         getter status : String
       end
 


### PR DESCRIPTION
## Summary
Introduces a new `Category` enum to the accounts domain, allowing accounts to be classified as Asset, Liability, Income, or Expense. This field is now required throughout the account lifecycle—from API requests through event sourcing to projections.

## Key Changes
- **New type:** Added `Category` enum in `app/src/config/types/accounts.cr` with `to_s` override for lowercase serialization
- **API layer:** Updated request and response DTOs to include the `category` field with JSON descriptions
- **Event sourcing:** 
  - Added `category` attribute to the `AccountOpeningRequested` event
  - Updated the account aggregate to store category as a property
  - Modified the opening event handler to apply category to aggregate state
- **Command layer:** Threaded category from API request through to event creation in the opening command
- **Projection:** 
  - Added `category` column to the accounts projection table
  - Updated the projection insert statement to persist category (converted to lowercase string)
  - Modified the query result mapping to parse category back to the enum type
- **Query layer:** Added category field to the accounts query result struct

## Implementation Details
- Category values are stored as lowercase strings in the database (via `to_s.downcase`) and parsed back to enum on retrieval
- The field is marked as `NOT NULL` in the projection table, making it mandatory for all accounts
- Follows the existing pattern of type enums in the codebase with custom serialization
- Maintains the event sourcing pipeline: request → command → event → projection → query

https://claude.ai/code/session_0162B7BBYNwz2WvSfCoYy2gm