### PR TITLE
Re-fetch completed/rejected approvals on scope change

### DIFF
--- a/app/frontend/src/components/views/Approvals.svelte
+++ b/app/frontend/src/components/views/Approvals.svelte
@@ -1,10 +1,36 @@
 <script>
-  import { viewData, pagination, ui, approvalsMeta } from '../../lib/store.svelte.js'
+  import { untrack } from 'svelte'
+  import { auth, viewData, pagination, ui, approvalsMeta } from '../../lib/store.svelte.js'
   import { loadView, loadMore, collectApproval, rejectApproval } from '../../lib/actions.js'
 
   let activeTab = $state('pending')
   let completedFetchAttempted = false
   let rejectedFetchAttempted = false
+
+  // When scope changes, reset completed/rejected tabs so they re-fetch with the new scope.
+  // Uses untrack() for activeTab so tab switches don't trigger this effect.
+  let scopeEffectMounted = false
+  $effect(() => {
+    void auth.scope
+    if (!scopeEffectMounted) { scopeEffectMounted = true; return }
+    completedFetchAttempted = false
+    rejectedFetchAttempted = false
+    viewData.approvals_completed = []
+    viewData.approvals_rejected = []
+    pagination.cursors.approvals_completed = null
+    pagination.cursors.approvals_rejected = null
+    pagination.hasMore.approvals_completed = false
+    pagination.hasMore.approvals_rejected = false
+    untrack(() => {
+      if (activeTab === 'completed') {
+        completedFetchAttempted = true
+        loadMore('approvals_completed')
+      } else if (activeTab === 'rejected') {
+        rejectedFetchAttempted = true
+        loadMore('approvals_rejected')
+      }
+    })
+  })
 
   let drawerApproval = $state(null)
   let comment = $state('')


### PR DESCRIPTION
When the scope selector changes, only the pending approvals list was
being reloaded. The completed and rejected tabs held stale in-memory
data because their per-tab fetch flags were never reset.

Add a $effect in Approvals.svelte that watches auth.scope and, on each
scope change after mount, clears the stale viewData/pagination for
approvals_completed and approvals_rejected and resets the fetch-attempt
guards. If the user is currently on one of those tabs the data is also
fetched immediately; otherwise the fresh fetch happens on the next tab
click.

https://claude.ai/code/session_01Hx1xvHPShAnbkAX2vk4zbk