### PR TITLE
Display git SHA in login page footer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,8 @@ test-clean:
 
 # Build the Svelte frontend inside Docker (node:22-alpine)
 build-frontend:
-	$(call dc-frontend-run, "npm install && npm run build")
+	GIT_SHA=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown) \
+	$(COMPOSE_CMD) $(COMPOSE_ARGS) run --entrypoint "sh -c" --rm -e GIT_SHA frontend "npm install && npm run build"
 
 # Run Linter
 lint:

--- a/app/frontend/src/components/Login.svelte
+++ b/app/frontend/src/components/Login.svelte
@@ -2,6 +2,8 @@
   import { login } from '../lib/actions.js'
   import { ui } from '../lib/store.svelte.js'
 
+  const gitSha = __GIT_SHA__
+
   let clientId = $state('')
   let clientSecret = $state('')
   let error = $state('')
@@ -48,6 +50,6 @@
       </form>
     </div>
 
-    <p class="text-center text-xs text-zinc-400 mt-4">CrystalBank &mdash; Event-sourced Banking Platform</p>
+    <p class="text-center text-xs text-zinc-400 mt-4">CrystalBank &mdash; Event-sourced Banking Platform<br />version: {gitSha}</p>
   </div>
 </div>

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -1,7 +1,19 @@
+import { execSync } from 'child_process'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
+const gitSha = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return 'unknown'
+  }
+})()
+
 export default defineConfig({
+  define: {
+    __GIT_SHA__: JSON.stringify(gitSha),
+  },
   plugins: [svelte()],
   build: {
     outDir: '../public',

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { execSync } from 'child_process'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
-const gitSha = (() => {
+const gitSha = process.env.GIT_SHA || (() => {
   try {
     return execSync('git rev-parse --short HEAD').toString().trim()
   } catch {


### PR DESCRIPTION
## Summary
Add git commit SHA to the frontend build process and display it in the login page footer for deployment visibility.

## Changes
- **Login component**: Import the git SHA and display it in the footer alongside the CrystalBank tagline

## Implementation Details
The git SHA is computed once during the Vite build process using `execSync()` and injected via the `define` config option, making it available as a compile-time constant in the frontend code. This allows operators to quickly verify which version is deployed without needing to check logs or external systems.

https://claude.ai/code/session_01XLTSgdFtm9X8Kiz1vqVqoU