### PR TITLE
Copy .git into Docker frontend builder so git rev-parse works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app/frontend
 COPY app/frontend/package.json ./
 RUN npm install
 COPY app/frontend/ ./
+COPY .git /app/.git
 # Vite outDir is '../public', so output lands at /app/public
 RUN npm run build
 


### PR DESCRIPTION
The frontend builder stage only COPYs app/frontend/, leaving .git
absent during npm run build. Dokploy triggers docker build directly
from the Dockerfile with no --build-arg injection, so git rev-parse
failed and the version fell back to 'unknown'. Placing .git one level
above the workdir lets git find it via parent-directory traversal.

https://claude.ai/code/session_01HcD4DegbZtJejEyoze4j9Z