### PR TITLE
Fix Git SHA detection in Vite build by adding git to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM node:22-alpine AS frontend-builder
 WORKDIR /app/frontend
 COPY app/frontend/package.json ./
 RUN npm install
+RUN apk add --no-cache git
 COPY app/frontend/ ./
 COPY .git /app/.git
 # Vite outDir is '../public', so output lands at /app/public

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -10,6 +10,8 @@ const gitSha = process.env.GIT_SHA || (() => {
   }
 })()
 
+console.log(`[vite] building with GIT_SHA=${gitSha}`)
+
 export default defineConfig({
   define: {
     __GIT_SHA__: JSON.stringify(gitSha),


### PR DESCRIPTION
## Summary
Fixes the Vite build process to correctly detect and log the Git SHA by ensuring the `git` command is available in the frontend builder Docker image.

## Key Changes
- **Dockerfile**: Added `RUN apk add --no-cache git` to the frontend-builder stage to make the `git` command available during the build
- **vite.config.js**: Added a console log statement to display the detected Git SHA during the build process for debugging visibility

## Implementation Details
The Vite configuration attempts to detect the Git SHA via `git rev-parse HEAD` when the `GIT_SHA` environment variable is not set. However, the `git` command was not available in the Alpine-based Node image, causing the detection to fail silently. This change ensures `git` is installed before the frontend source is copied, allowing the SHA detection to work correctly.

The added logging provides visibility into which Git SHA is being embedded into the frontend build, which is useful for debugging version mismatches between the API and frontend.

https://claude.ai/code/session_01WYRQ2j1qN2C9TRy8hZWRhc