### PR TITLE
Visually de-emphasize inactive/pending entities in tables

### DIFF
--- a/app/frontend/src/components/views/AccountDetail.svelte
+++ b/app/frontend/src/components/views/AccountDetail.svelte
@@ -357,8 +357,8 @@
       </thead>
       <tbody>
         {#each virtualAccounts as va (va.id)}
-          <tr>
-            <td><span class="mono text-xs">{shortId(va.id)}</span></td>
+          <tr class:opacity-60={va.status === 'pending_activation' || va.status === 'inactive'}>
+            <td><span class="mono text-xs break-all select-all">{va.id}</span></td>
             <td class="font-medium">{va.name}</td>
             <td><span class="badge {statusBadgeClass(va.status)}">{formatStatus(va.status)}</span></td>
             <td>

--- a/app/frontend/src/components/views/Customers.svelte
+++ b/app/frontend/src/components/views/Customers.svelte
@@ -45,7 +45,7 @@
         <tr><td colspan="5" class="text-center py-10 text-zinc-400 text-sm">No customers found</td></tr>
       {/if}
       {#each viewData.customers as c (c.id)}
-        <tr onclick={() => drawerCustomer = c} class="cursor-pointer">
+        <tr onclick={() => drawerCustomer = c} class="cursor-pointer" class:opacity-60={c.status === 'pending_approval' || c.status === 'inactive'}>
           <td><span class="mono text-xs">{c.id}</span></td>
           <td class="font-medium">{c.name}</td>
           <td><span class="badge" class:badge-blue={c.type === 'individual'} class:badge-amber={c.type !== 'individual'}>{c.type}</span></td>

--- a/app/frontend/src/components/views/SepaCreditTransfers.svelte
+++ b/app/frontend/src/components/views/SepaCreditTransfers.svelte
@@ -123,7 +123,7 @@
         </tr>
       {/if}
       {#each viewData.sepa_credit_transfers as t (t.id)}
-        <tr onclick={() => drawerTransfer = t} class="cursor-pointer">
+        <tr onclick={() => drawerTransfer = t} class="cursor-pointer" class:opacity-60={t.status === 'pending_approval'}>
           <td><span class="mono text-xs">{t.end_to_end_id}</span></td>
           <td class="font-medium">{t.creditor_name}</td>
           <td><span class="mono text-xs">{t.creditor_iban}</span></td>

--- a/app/frontend/src/components/views/Users.svelte
+++ b/app/frontend/src/components/views/Users.svelte
@@ -151,7 +151,7 @@
         <tr><td colspan="5" class="text-center py-10 text-zinc-400 text-sm">No users found</td></tr>
       {/if}
       {#each viewData.users as u (u.id)}
-        <tr onclick={() => openDrawer(u)} class="cursor-pointer">
+        <tr onclick={() => openDrawer(u)} class="cursor-pointer" class:opacity-60={u.status === 'pending_approval' || u.status === 'inactive'}>
           <td><span class="mono text-xs">{u.id}</span></td>
           <td class="font-medium">{u.name}</td>
           <td class="text-zinc-500">{u.email}</td>


### PR DESCRIPTION
## Summary
Add visual styling to de-emphasize rows for entities in inactive or pending approval/activation states across multiple list views. This improves UX by making it immediately clear which entities are not yet active or are awaiting approval.

## Changes
- **AccountDetail.svelte**: Apply `opacity-60` class to virtual account rows when status is `pending_activation` or `inactive`. Also changed display from shortened ID to full ID with `break-all` and `select-all` classes for better usability.
- **Customers.svelte**: Apply `opacity-60` class to customer rows when status is `pending_approval` or `inactive`.
- **SepaCreditTransfers.svelte**: Apply `opacity-60` class to transfer rows when status is `pending_approval`.
- **Users.svelte**: Apply `opacity-60` class to user rows when status is `pending_approval` or `inactive`.

## Implementation Details
- Uses Svelte's conditional class binding (`class:opacity-60={condition}`) to apply reduced opacity styling
- Each view checks the appropriate status values for its entity type (pending_activation/inactive for accounts, pending_approval/inactive for customers and users, pending_approval for transfers)
- The styling is consistent across all views, improving visual coherence in the UI

https://claude.ai/code/session_01JdutdNvrQu8sotArB1KGuX