### PR TITLE
Add maker-checker approval flow to ledger transactions

### DIFF
--- a/app/frontend/src/components/views/Transactions.svelte
+++ b/app/frontend/src/components/views/Transactions.svelte
@@ -354,9 +354,13 @@
           {/each}
         </div>
 
+        <div class="rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-700 mb-4">
+          This transaction will be submitted for approval. Postings appear in the ledger only after a user with the <strong>ledger transactions approval</strong> permission collects the approval.
+        </div>
+
         <div class="flex gap-2 justify-end">
           <button type="button" onclick={() => showModal = false} class="btn btn-ghost">Cancel</button>
-          <button type="submit" class="btn btn-primary" disabled={ui.loading}>Create Transaction</button>
+          <button type="submit" class="btn btn-primary" disabled={ui.loading}>Submit for Approval</button>
         </div>
 
       </form>

--- a/app/frontend/src/lib/actions.js
+++ b/app/frontend/src/lib/actions.js
@@ -290,8 +290,8 @@ export async function createLedgerTransaction({ currency, entries, posting_date,
       ...(remittance_information ? { remittance_information } : {}),
       ...(Object.keys(meta).length > 0 ? { metadata: meta } : {}),
     }, { idempotency: true })
-    addToast('Transaction created')
-    await loadView('postings')
+    addToast('Transaction submitted — awaiting approval')
+    await loadView('approvals')
   } catch (e) {
     addToast(e.message, 'error')
     throw e

--- a/app/spec/domains/ledger/transactions/api/concerns/responses_spec.cr
+++ b/app/spec/domains/ledger/transactions/api/concerns/responses_spec.cr
@@ -2,12 +2,14 @@ require "../../../../../spec_helper"
 
 describe CrystalBank::Domains::Ledger::Transactions::Api::Responses do
   describe "TransactionResponse" do
-    it "serializes to json with an id field" do
+    it "serializes to json with id and approval_id fields" do
       uuid = UUID.v7
-      response = Ledger::Transactions::Api::Responses::TransactionResponse.new(uuid)
+      approval_id = UUID.v7
+      response = Ledger::Transactions::Api::Responses::TransactionResponse.new(uuid, approval_id)
 
       json = JSON.parse(response.to_json)
       json["id"].as_s.should eq(uuid.to_s)
+      json["approval_id"].as_s.should eq(approval_id.to_s)
     end
   end
 end

--- a/app/spec/domains/ledger/transactions/api/transactions_spec.cr
+++ b/app/spec/domains/ledger/transactions/api/transactions_spec.cr
@@ -50,18 +50,20 @@ describe CrystalBank::Domains::Ledger::Transactions::Api::Transactions do
       }.to_json
 
       request = Ledger::Transactions::Api::Requests::TransactionRequest.from_json(json)
-      transaction_id = Ledger::Transactions::Request::Commands::Request.new.call(request, context)
+      result = Ledger::Transactions::Request::Commands::Request.new.call(request, context)
 
-      transaction_id.should be_a(UUID)
+      result[:transaction_id].should be_a(UUID)
+      result[:approval_id].should be_a(UUID)
 
-      # Verify the Requested event was persisted for the returned id
-      aggregate = Ledger::Transactions::Aggregate.new(transaction_id)
+      # Verify the Requested event was persisted and the transaction is pending approval
+      aggregate = Ledger::Transactions::Aggregate.new(result[:transaction_id])
       aggregate.hydrate
 
       aggregate.state.currency.should eq(CrystalBank::Types::Currencies::Supported::EUR)
       aggregate.state.remittance_information.should eq("Invoice INV-2024-001")
       aggregate.state.scope_id.should eq(scope_id)
       aggregate.state.entries.not_nil!.size.should eq(2)
+      aggregate.state.status.should eq("pending_approval")
     end
 
     it "rejects the request when a referenced account is not open" do

--- a/app/spec/domains/ledger/transactions/commands/request/process_approval_spec.cr
+++ b/app/spec/domains/ledger/transactions/commands/request/process_approval_spec.cr
@@ -1,0 +1,91 @@
+require "../../../../../spec_helper"
+
+describe CrystalBank::Domains::Ledger::Transactions::Request::Commands::ProcessApproval do
+  it "accepts the ledger transaction after the approval is completed" do
+    tx_id = UUID.v7
+    scope_id = UUID.v7
+
+    requested = Test::Ledger::Transactions::Events::Request::Requested.new.create(aggr_id: tx_id)
+    TEST_EVENT_STORE.append(requested)
+
+    approval_id = Approvals::Creation::Commands::Request.new.call(
+      source_aggregate_type: "LedgerTransaction",
+      source_aggregate_id: tx_id,
+      scope_id: scope_id,
+      required_approvals: ["write_ledger_transactions_request_approval"],
+      actor_id: UUID.v7,
+    )
+
+    completed_event = Approvals::Collection::Events::Completed.new(
+      actor_id: nil,
+      aggregate_id: approval_id,
+      aggregate_version: 2,
+      command_handler: "test",
+      comment: "approved",
+    )
+    TEST_EVENT_STORE.append(completed_event)
+
+    apply_projection(approval_id)
+
+    transaction = Ledger::Transactions::Aggregate.new(tx_id)
+    transaction.hydrate
+
+    transaction.state.status.should eq("accepted")
+  end
+
+  it "ignores a completed approval with a different source aggregate type" do
+    approval_id = Approvals::Creation::Commands::Request.new.call(
+      source_aggregate_type: "SomeUnhandledType",
+      source_aggregate_id: UUID.v7,
+      scope_id: UUID.v7,
+      required_approvals: ["write_ledger_transactions_request_approval"],
+      actor_id: UUID.v7,
+    )
+
+    completed_event = Approvals::Collection::Events::Completed.new(
+      actor_id: nil,
+      aggregate_id: approval_id,
+      aggregate_version: 2,
+      command_handler: "test",
+      comment: "approved",
+    )
+    TEST_EVENT_STORE.append(completed_event)
+
+    apply_projection(approval_id)
+  end
+
+  it "creates postings in the projection after approval" do
+    tx_id = UUID.v7
+
+    requested = Test::Ledger::Transactions::Events::Request::Requested.new.create(aggr_id: tx_id)
+    TEST_EVENT_STORE.append(requested)
+
+    approval_id = Approvals::Creation::Commands::Request.new.call(
+      source_aggregate_type: "LedgerTransaction",
+      source_aggregate_id: tx_id,
+      scope_id: UUID.new("00000000-0000-0000-0000-100000000001"), # matches factory scope_id
+      required_approvals: ["write_ledger_transactions_request_approval"],
+      actor_id: UUID.v7,
+    )
+
+    completed_event = Approvals::Collection::Events::Completed.new(
+      actor_id: nil,
+      aggregate_id: approval_id,
+      aggregate_version: 2,
+      command_handler: "test",
+      comment: "approved",
+    )
+    TEST_EVENT_STORE.append(completed_event)
+
+    # Replay approval events — this triggers ProcessApproval which appends Accepted to the store
+    apply_projection(approval_id)
+    # Replay ledger transaction events — this publishes Accepted and triggers the Postings projection
+    apply_projection(tx_id)
+
+    count = TEST_PROJECTION_DB.scalar(
+      %(SELECT count(*) FROM "projections"."postings" WHERE transaction_id = $1),
+      tx_id
+    )
+    count.should eq(2)
+  end
+end

--- a/app/spec/domains/ledger/transactions/commands/request/request_spec.cr
+++ b/app/spec/domains/ledger/transactions/commands/request/request_spec.cr
@@ -32,11 +32,9 @@ describe CrystalBank::Domains::Ledger::Transactions::Request::Commands::Request 
     TestEnv.credit_account_id = credit_account_id
   end
 
-  it "creates a transaction when accounts are open and scope is valid" do
+  it "creates a transaction and an approval request when accounts are open and scope is valid" do
     scope_id = UUID.v7
     user_id = UUID.v7
-    debit_account_id = UUID.v7
-    credit_account_id = UUID.v7
 
     context = CrystalBank::Api::Context.new(
       user_id: user_id,
@@ -60,7 +58,19 @@ describe CrystalBank::Domains::Ledger::Transactions::Request::Commands::Request 
     request = Ledger::Transactions::Api::Requests::TransactionRequest.from_json(json)
 
     result = Ledger::Transactions::Request::Commands::Request.new.call(request, context)
-    result.should be_a(UUID)
+    result[:transaction_id].should be_a(UUID)
+    result[:approval_id].should be_a(UUID)
+
+    # Ledger transaction should be in pending_approval state
+    aggregate = Ledger::Transactions::Aggregate.new(result[:transaction_id])
+    aggregate.hydrate
+    aggregate.state.status.should eq("pending_approval")
+
+    # Approval aggregate should reference the ledger transaction
+    approval = Approvals::Aggregate.new(result[:approval_id])
+    approval.hydrate
+    approval.state.source_aggregate_type.should eq("LedgerTransaction")
+    approval.state.source_aggregate_id.should eq(result[:transaction_id])
   end
 
   it "raises when an account is not open" do

--- a/app/src/config/initializers/event_bus.cr
+++ b/app/src/config/initializers/event_bus.cr
@@ -32,6 +32,7 @@ bus.subscribe(Approvals::Collection::Events::Collected, Approvals::Projections::
 bus.subscribe(Approvals::Rejection::Events::Rejected, Approvals::Projections::Approvals)
 bus.subscribe(Approvals::Collection::Events::Completed, Approvals::Projections::Approvals)
 bus.subscribe(Approvals::Collection::Events::Completed, Accounts::Opening::Commands::ProcessApproval)
+bus.subscribe(Approvals::Collection::Events::Completed, Ledger::Transactions::Request::Commands::ProcessApproval)
 bus.subscribe(Approvals::Collection::Events::Completed, Payments::Sepa::CreditTransfers::Initiation::Commands::ProcessApproval)
 bus.subscribe(Approvals::Collection::Events::Completed, Users::Onboarding::Commands::ProcessApproval)
 bus.subscribe(Approvals::Collection::Events::Completed, Users::AssignRoles::Commands::ProcessApproval)
@@ -75,7 +76,6 @@ bus.subscribe(Scopes::NameChange::Events::Accepted, Scopes::Projections::Scopes)
 bus.subscribe(Approvals::Collection::Events::Completed, Scopes::NameChange::Commands::ProcessApproval)
 
 # Ledger
-bus.subscribe(Ledger::Transactions::Request::Events::Requested, Ledger::Transactions::Request::Commands::ProcessRequest)
 bus.subscribe(Ledger::Transactions::Request::Events::Accepted, Ledger::Transactions::Projections::Postings)
 
 # Payments — SEPA Credit Transfers

--- a/app/src/config/permissions.cr
+++ b/app/src/config/permissions.cr
@@ -68,6 +68,7 @@ module CrystalBank
       description: "Permissions for creating ledger entries and reading posting records.",
       permissions: [
         {key: "WRITE_ledger_transactions_request", description: "Submit a double-entry ledger transaction request."},
+        {key: "WRITE_ledger_transactions_request_approval", description: "Approve or reject a pending ledger transaction request."},
         {key: "READ_postings_list", description: "List ledger posting records visible within the caller's scope."},
       ],
     },

--- a/app/src/domains/ledger/transactions/aggregates/aggregate.cr
+++ b/app/src/domains/ledger/transactions/aggregates/aggregate.cr
@@ -35,6 +35,7 @@ module CrystalBank::Domains::Ledger::Transactions
       property external_ref : String?
       property channel : String?
       property scope_id : UUID?
+      property status : String?
     end
 
     getter state : State

--- a/app/src/domains/ledger/transactions/aggregates/request.cr
+++ b/app/src/domains/ledger/transactions/aggregates/request.cr
@@ -5,6 +5,7 @@ module CrystalBank::Domains::Ledger::Transactions
         # Apply 'Ledger::Transactions::Request::Events::Accepted' to the aggregate state
         def apply(event : Ledger::Transactions::Request::Events::Accepted)
           @state.increase_version(event.header.aggregate_version)
+          @state.status = "accepted"
         end
 
         # Apply 'Ledger::Transactions::Request::Events::Requested' to the aggregate state
@@ -22,6 +23,7 @@ module CrystalBank::Domains::Ledger::Transactions
           @state.external_ref = body.external_ref
           @state.channel = body.channel
           @state.scope_id = body.scope_id
+          @state.status = "pending_approval"
         end
       end
     end

--- a/app/src/domains/ledger/transactions/api/concerns/responses.cr
+++ b/app/src/domains/ledger/transactions/api/concerns/responses.cr
@@ -7,7 +7,10 @@ module CrystalBank::Domains::Ledger::Transactions
         @[JSON::Field(format: "uuid", description: "ID of the created ledger transaction")]
         getter id : UUID
 
-        def initialize(@id : UUID)
+        @[JSON::Field(format: "uuid", description: "ID of the approval request — transaction posts only after approval is collected")]
+        getter approval_id : UUID
+
+        def initialize(@id : UUID, @approval_id : UUID)
         end
       end
 

--- a/app/src/domains/ledger/transactions/api/transactions.cr
+++ b/app/src/domains/ledger/transactions/api/transactions.cr
@@ -17,9 +17,9 @@ module CrystalBank::Domains::Ledger::Transactions
       def create(r : TransactionRequest) : Responses::TransactionResponse
         authorized?("write_ledger_transactions_request")
 
-        aggregate_id = ::Ledger::Transactions::Request::Commands::Request.new.call(r, context)
+        result = ::Ledger::Transactions::Request::Commands::Request.new.call(r, context)
 
-        Responses::TransactionResponse.new(aggregate_id)
+        Responses::TransactionResponse.new(result[:transaction_id], result[:approval_id])
       end
 
       # List postings

--- a/app/src/domains/ledger/transactions/commands/request/process_approval.cr
+++ b/app/src/domains/ledger/transactions/commands/request/process_approval.cr
@@ -1,0 +1,38 @@
+module CrystalBank::Domains::Ledger::Transactions
+  module Request
+    module Commands
+      class ProcessApproval < ES::Command
+        def call
+          approval_aggregate_id = @aggregate_id.as(UUID)
+
+          # Hydrate the approval aggregate to get source info
+          approval = Approvals::Aggregate.new(approval_aggregate_id)
+          approval.hydrate
+
+          # Only process if this approval is for a LedgerTransaction
+          return unless approval.state.source_aggregate_type == "LedgerTransaction"
+
+          transaction_id = approval.state.source_aggregate_id.as(UUID)
+
+          # Hydrate the ledger transaction aggregate
+          transaction = Ledger::Transactions::Aggregate.new(transaction_id)
+          transaction.hydrate
+
+          # Guard: only accept once
+          return if transaction.state.status == "accepted"
+
+          next_version = transaction.state.next_version
+
+          event = Ledger::Transactions::Request::Events::Accepted.new(
+            actor_id: nil,
+            aggregate_id: transaction_id,
+            aggregate_version: next_version,
+            command_handler: self.class.to_s,
+          )
+
+          @event_store.append(event)
+        end
+      end
+    end
+  end
+end

--- a/app/src/domains/ledger/transactions/commands/request/request.cr
+++ b/app/src/domains/ledger/transactions/commands/request/request.cr
@@ -90,10 +90,10 @@ module CrystalBank::Domains::Ledger::Transactions
           currency_str = r.currency.to_s.upcase
           amount_formatted = "%.2f %s" % [debit_total / 100.0, currency_str]
           summary = if (ref = r.remittance_information) && !ref.empty?
-            "#{amount_formatted} · #{ref}"
-          else
-            "#{amount_formatted} · #{entries.size} entries"
-          end
+                      "#{amount_formatted} · #{ref}"
+                    else
+                      "#{amount_formatted} · #{entries.size} entries"
+                    end
 
           approval_fields = [
             Approvals::ApprovalSubject::Field.new("Currency", currency_str),

--- a/app/src/domains/ledger/transactions/commands/request/request.cr
+++ b/app/src/domains/ledger/transactions/commands/request/request.cr
@@ -2,7 +2,7 @@ module CrystalBank::Domains::Ledger::Transactions
   module Request
     module Commands
       class Request < ES::Command
-        def call(r : Ledger::Transactions::Api::Requests::TransactionRequest, c : CrystalBank::Api::Context) : UUID
+        def call(r : Ledger::Transactions::Api::Requests::TransactionRequest, c : CrystalBank::Api::Context) : {transaction_id: UUID, approval_id: UUID}
           actor = c.user_id
           scope = c.scope
           raise CrystalBank::Exception::InvalidArgument.new("Invalid scope") unless scope
@@ -84,7 +84,52 @@ module CrystalBank::Domains::Ledger::Transactions
 
           @event_store.append(event)
 
-          UUID.new(event.header.aggregate_id.to_s)
+          transaction_id = UUID.new(event.header.aggregate_id.to_s)
+
+          # Build a human-readable snapshot so approvers have full context
+          currency_str = r.currency.to_s.upcase
+          amount_formatted = "%.2f %s" % [debit_total / 100.0, currency_str]
+          summary = if (ref = r.remittance_information) && !ref.empty?
+            "#{amount_formatted} · #{ref}"
+          else
+            "#{amount_formatted} · #{entries.size} entries"
+          end
+
+          approval_fields = [
+            Approvals::ApprovalSubject::Field.new("Currency", currency_str),
+            Approvals::ApprovalSubject::Field.new("Total Amount", amount_formatted),
+            Approvals::ApprovalSubject::Field.new("Entries", entries.size.to_s),
+            Approvals::ApprovalSubject::Field.new("Posting Date", r.posting_date),
+            Approvals::ApprovalSubject::Field.new("Value Date", r.value_date),
+          ] of Approvals::ApprovalSubject::Field
+
+          if (ref = r.remittance_information) && !ref.empty?
+            approval_fields << Approvals::ApprovalSubject::Field.new("Remittance", ref)
+          end
+
+          entries_data.each_with_index do |entry, i|
+            account_name = found_by_id[entry.account_id]?.try(&.name) || entry.account_id.to_s
+            entry_amount = "%.2f %s" % [entry.amount / 100.0, currency_str]
+            label = "Entry #{i + 1} (#{entry.direction.capitalize})"
+            approval_fields << Approvals::ApprovalSubject::Field.new(label, "#{account_name} · #{entry_amount} · #{entry.entry_type}")
+          end
+
+          approval_subject = Approvals::ApprovalSubject.new(
+            title: "Ledger Transaction",
+            summary: summary,
+            fields: approval_fields,
+          )
+
+          approval_id = Approvals::Creation::Commands::Request.new.call(
+            source_aggregate_type: "LedgerTransaction",
+            source_aggregate_id: transaction_id,
+            scope_id: scope,
+            required_approvals: ["write_ledger_transactions_request_approval"],
+            actor_id: actor,
+            subject: approval_subject,
+          )
+
+          {transaction_id: transaction_id, approval_id: approval_id}
         end
       end
     end

--- a/app/src/domains/ledger/transactions/load.cr
+++ b/app/src/domains/ledger/transactions/load.cr
@@ -7,6 +7,7 @@ require "./api/transactions"
 # Commands
 require "./commands/request/request"
 require "./commands/request/process_request"
+require "./commands/request/process_approval"
 
 # Events
 require "./events/request/accepted"

--- a/app/src/domains/payments/sepa/credit_transfers/commands/initiation/process_approval.cr
+++ b/app/src/domains/payments/sepa/credit_transfers/commands/initiation/process_approval.cr
@@ -79,6 +79,18 @@ module CrystalBank::Domains::Payments::Sepa::CreditTransfers
 
           ledger_transaction_id = UUID.new(ledger_event.header.aggregate_id.to_s)
 
+          # Immediately accept the ledger transaction — no separate approval is required
+          # because this transaction is already the result of an approved SEPA CT.
+          ledger_aggregate = Ledger::Transactions::Aggregate.new(ledger_transaction_id)
+          ledger_aggregate.hydrate
+          ledger_accepted_event = Ledger::Transactions::Request::Events::Accepted.new(
+            actor_id: nil,
+            aggregate_id: ledger_transaction_id,
+            aggregate_version: ledger_aggregate.state.next_version,
+            command_handler: self.class.to_s,
+          )
+          @event_store.append(ledger_accepted_event)
+
           # Mark the SEPA CT as accepted
           next_version = payment.state.next_version
 


### PR DESCRIPTION
Ledger transactions now go through the same approval workflow as SEPA
Credit Transfers and other regulated operations:

- `POST /ledger/transactions` creates a transaction in pending_approval
  state and returns both a transaction_id and an approval_id.
- The transaction posts to the ledger only after a user holding
  `WRITE_ledger_transactions_request_approval` collects the approval.
- The approval subject carries full context (currency, total amount,
  posting/value dates, remittance info, per-entry account names and
  amounts) so approvers can make an informed decision.

Backend changes:
- New permission: WRITE_ledger_transactions_request_approval
- Aggregate state gains a status field (pending_approval → accepted)
- New ProcessApproval command wires the approval completion to the
  Accepted event; registered on Approvals::Collection::Events::Completed
  in event_bus.cr
- Request command now returns {transaction_id, approval_id} and builds
  an ApprovalSubject snapshot
- SEPA CT ProcessApproval emits Accepted directly after Requested so
  system-initiated ledger entries bypass the user-facing approval flow
- Removed the ProcessRequest auto-subscription from the event bus

Tests:
- request_spec updated to assert pending_approval state and approval link
- New process_approval_spec covering accept, ignore, and postings creation
- transactions_spec (API) updated for the new response shape

Frontend:
- Submit button renamed to "Submit for Approval"; warning banner added
- Toast updated; on success the app navigates to the Approvals view

https://claude.ai/code/session_016AGeFS8qob1S4LZtXNyUmF