### PR TITLE
Replace onMount with $effect for auth-reactive data fetching

### DIFF
--- a/app/frontend/src/components/views/Dashboard.svelte
+++ b/app/frontend/src/components/views/Dashboard.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { onMount } from 'svelte'
-  import { ui } from '../../lib/store.svelte.js'
+  import { auth, ui } from '../../lib/store.svelte.js'
   import { switchView } from '../../lib/actions.js'
   import { apiFetch } from '../../lib/api.js'
 
@@ -28,8 +27,13 @@
     sepa_credit_transfers: '/payments/sepa/credit-transfers/?limit=200&status=pending',
   }
 
-  onMount(async () => {
-    await Promise.allSettled(
+  $effect(() => {
+    // Track auth.scope so the effect re-runs on scope changes
+    const _scope = auth.scope
+    for (const key of Object.keys(stats)) {
+      stats[key] = { count: null, hasMore: false }
+    }
+    Promise.allSettled(
       Object.entries(PATHS).map(async ([key, path]) => {
         try {
           const res = await apiFetch('GET', path)


### PR DESCRIPTION
## Summary
Refactored the Dashboard component to use Svelte 5's `$effect` rune instead of the deprecated `onMount` lifecycle hook, making the data fetch reactive to authentication scope changes.

## Key Changes
- Removed `onMount` import and replaced with `$effect` for reactive data fetching
- Added `auth` to the store imports to track authentication state
- Implemented reactive dependency tracking by reading `auth.scope` within the effect to trigger re-runs on scope changes
- Reset all stats to `{ count: null, hasMore: false }` at the start of each effect run to ensure clean state
- Removed `await` from `Promise.allSettled()` call (effect doesn't need to wait for completion)

## Implementation Details
The effect now re-runs whenever `auth.scope` changes, ensuring that dashboard statistics are refreshed when the user's authentication scope is updated. This is more idiomatic for Svelte 5 and provides better reactivity than the previous mount-once approach.

https://claude.ai/code/session_01QKN4ermMu3a4mXGZyJPdRJ