### PR TITLE
Update CLAUDE.md: fix stale paths and add structure aids for smaller models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,17 @@ make build-frontend   # Compile Svelte SPA to app/public/
 make logs             # Tail docker logs
 ```
 
-**Inside the console container:**
+**Inside the console container** (the repo's `app/` directory is mounted at `/app`):
 ```bash
 crystal src/server/start.cr              # Start API server
 crystal src/server/start.cr --seed       # Seed initial admin users (prints credentials)
 crystal src/server/start.cr -d -f openapi.json  # Generate OpenAPI spec
 ```
 
-**Run a single spec:**
+**Run a single spec** (note: spec paths mirror `app/src/domains/`, including nested domains):
 ```bash
-docker compose -f docker-compose.test.yml run --entrypoint "bash -c" --rm cmd \
-  "crystal spec spec/domains/accounts/commands/opening/request_spec.cr"
+docker compose -f docker-compose.test.yml -p crystalbank run --entrypoint "bash -c" --rm cmd \
+  "crystal spec spec/domains/account_management/accounts/commands/opening/request_spec.cr"
 ```
 
 **Frontend dev (hot reload):**
@@ -51,13 +51,53 @@ CrystalBank is a strict **Event Sourcing + CQRS** system. Every state change flo
 
 ```
 HTTP Request
-    → API Controller  (app/src/domains/{domain}/api/)
-    → Command         (app/src/domains/{domain}/commands/)
-    → Event appended  (app/src/domains/{domain}/events/)
+    → API Controller  (api/)          validates request, checks permission
+    → Command         (commands/)     validates business rules
+    → Event appended  (events/)       immutable fact, written to event store
     → Event Bus       (app/src/config/initializers/event_bus.cr)
-    → Projection      (app/src/domains/{domain}/projections/)  ← writes to DB
-    → Query           (app/src/domains/{domain}/queries/)       ← reads from DB
+    → Projection      (projections/)  ← writes read model to DB
+    → Query           (queries/)      ← reads from DB, scope-filtered
 ```
+
+**Domains** live under `app/src/domains/`. Two domains have nested subdomains — their paths have one extra level:
+
+```
+app/src/domains/
+├── account_management/
+│   ├── accounts/            # module CrystalBank::Domains::Accounts
+│   └── virtual_accounts/    # module CrystalBank::Domains::VirtualAccounts
+├── api_keys/
+├── approvals/
+├── customers/
+├── events/                  # read-only API over the event log
+├── ledger/
+│   └── transactions/
+├── payments/
+├── platform/
+├── roles/
+├── scopes/
+└── users/
+```
+
+⚠️ **Namespace ≠ directory path.** The module namespace is `CrystalBank::Domains::{Entity}` and does *not* include the parent folder: code in `domains/account_management/accounts/` lives in `CrystalBank::Domains::Accounts`, not `...::AccountManagement::Accounts`.
+
+**Inside each domain** the layout is always:
+
+```
+{domain}/
+├── aggregates/     # hydrated from events; current state for command validation
+├── api/            # controllers + request/response structs (api/concerns/)
+├── commands/       # one folder per operation, e.g. commands/opening/
+├── events/         # one file per event, e.g. events/opening/requested.cr
+├── projections/    # event → read-model row transformers
+├── queries/        # scope-filtered reads from projection tables
+└── load.cr         # explicit requires for every file in the domain
+```
+
+**Command naming convention** — operations that need approval come as a triad:
+- `request.cr` — user-initiated command, appends a `Requested` event
+- `process_request.cr` — bus-triggered, decides auto-accept vs. approval workflow
+- `process_approval.cr` — bus-triggered when the approval collection completes
 
 **Database layout:**
 - `eventstore` schema — immutable event log (event store)
@@ -66,15 +106,31 @@ HTTP Request
 
 **Cross-domain interaction** happens in exactly two ways:
 1. The event bus wires cross-domain command triggers (e.g. a completed approval triggers the originating domain's command)
-2. A command calls another domain's Query to read state
+2. A command calls another domain's Query to read state (e.g. `Customers::Queries::Customers.new.find_all(context: c, ...)`)
 
-**Approval workflow** is a generic subsystem in `domains/approvals/`. Any domain can require maker-checker by generating an approval-request event and listening for the approval-completion event.
+**Approval workflow** is a generic subsystem in `domains/approvals/`. Any domain can require maker-checker by generating an approval-request event and listening for `Approvals::Collection::Events::Completed` in `event_bus.cr`.
 
 **Multi-tenancy / access control:**
 - Scopes form a hierarchy; every resource belongs to a scope
-- Permissions (~75) are defined via DSL in `app/src/config/permissions.cr`
-- A `Context` object (user ID, roles, scopes, requested permission) flows from the API middleware into every command and query
+- Permissions (~50) are defined via the `define_permissions` DSL in `app/src/config/permissions.cr`, grouped by domain
+- A `Context` object (user ID, roles, scopes, requested permission) flows from the API middleware into every command and query as `c : CrystalBank::Api::Context`
 - Queries **automatically** filter by `context.available_scopes`
+
+---
+
+## Checklist: adding a new operation to a domain
+
+Follow these steps in order. Missing a registration step causes runtime failures, not compile errors.
+
+1. **Event** — create `events/{operation}/{name}.cr`. Subclass `ES::Event`, include `ES::EventDSL`, use `define_event "{Aggregate}", "{aggregate}.{operation}.{name}" do ... end` with `attribute` declarations.
+2. **Register the event** in `app/src/config/initializers/event_handlers.cr` with `event_handlers.register(...)`. Every event class must be registered or aggregate hydration fails at runtime.
+3. **Command** — create `commands/{operation}/request.cr` (plus `process_request.cr` / `process_approval.cr` if it needs the approval workflow). Subclass `ES::Command`; validate, build the event, `@event_store.append(event)`.
+4. **Projection** — handle the new event in the domain's projection under `projections/`.
+5. **Wire the bus** in `app/src/config/initializers/event_bus.cr`: `bus.subscribe(Event, Projection)` and any `bus.subscribe(Event, Command)` triggers.
+6. **API** — add the endpoint in `api/`, with request/response structs in `api/concerns/`, declaring the required permission.
+7. **Permission** — add the key to the matching group in `app/src/config/permissions.cr` (`READ_...` / `WRITE_...` naming).
+8. **Require every new file** in the domain's `load.cr`. New types go in `app/src/config/types/` and are required from `app/src/config/load.cr`. New domains are required from `app/src/load.cr` — insert at the correct position, order is intentional.
+9. **Spec** — mirror the source path under `app/spec/domains/...`. Seed events with the factories in `app/spec/factories/events/`, replay with `apply_projection(aggregate_id)` (defined in `spec_helper.cr`), then assert on projection state.
 
 ---
 
@@ -87,7 +143,8 @@ HTTP Request
 - **Test with factories + `apply_projection()`.** Seed events directly into the store via factories, replay through the bus with `apply_projection(aggregate_id)`, then assert on projection state.
 - **Put new account/currency/payment types in `app/src/config/types/`.** That's where the type catalogue lives.
 - **Wire new event-bus subscriptions in `app/src/config/initializers/event_bus.cr`** — that file is the single source of truth for cross-domain event wiring.
-- **Register every new event class in `app/src/config/initializers/event_handlers.cr`** — the event store uses this registry to deserialize events when hydrating aggregates. Every event defined with `define_event` must have a matching `event_handlers.register(...)` call, or hydration will fail at runtime.
+- **Register every new event class in `app/src/config/initializers/event_handlers.cr`** — the event store uses this registry to deserialize events when hydrating aggregates.
+- **Copy an existing domain when unsure.** `account_management/accounts` is the most complete reference implementation (approval triad, blocking, closure, projections, specs).
 
 ---
 


### PR DESCRIPTION
- Fix spec example path (accounts lives under account_management/)
- Correct permission count (~50, not ~75) and name the define_permissions DSL
- Document the actual domain tree, including nested account_management/
  and ledger/ subdomains
- Call out the directory-vs-namespace mismatch (CrystalBank::Domains::Accounts
  vs domains/account_management/accounts/)
- Document the standard per-domain layout (incl. aggregates/, previously
  missing from the pipeline diagram) and the request/process_request/
  process_approval command triad
- Add an ordered checklist for adding a new operation, covering the
  runtime-failure registration steps (event_handlers, event_bus, load.cr)
- Point to account_management/accounts as the reference implementation
- Add -p crystalbank to the single-spec command to match the Makefile

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S17NGbTK2Bh7u9onwbDn2Z